### PR TITLE
Fix server build & ability to manually run

### DIFF
--- a/Assets/PurrNet-Dissonance/PurrNetCommsNetwork.cs
+++ b/Assets/PurrNet-Dissonance/PurrNetCommsNetwork.cs
@@ -20,15 +20,21 @@ namespace Dissonance.Integrations.PurrNet
         {
             comms = GetComponent<DissonanceComms>();
             InstanceHandler.RegisterInstance(this);
-            NetworkManager.main.onClientConnectionState += OnClientConnectionState;
+#if UNITY_SERVER
+            NetworkManager.main.onServerConnectionState += OnConnectionState;
+#else
+            NetworkManager.main.onClientConnectionState += OnConnectionState;
+#endif
         }
+
         private void OnDestroy()
         {
             InstanceHandler.UnregisterInstance<PurrNetCommsNetwork>();
-            NetworkManager.main.onClientConnectionState -= OnClientConnectionState;
+            NetworkManager.main.onClientConnectionState -= OnConnectionState;
+            NetworkManager.main.onServerConnectionState -= OnConnectionState;
         }
 
-        private void OnClientConnectionState(ConnectionState connectionState)
+        private void OnConnectionState(ConnectionState connectionState)
         {
             if (connectionState == ConnectionState.Connected)
             {

--- a/Assets/PurrNet-Dissonance/PurrNetCommsNetwork.cs
+++ b/Assets/PurrNet-Dissonance/PurrNetCommsNetwork.cs
@@ -20,6 +20,12 @@ namespace Dissonance.Integrations.PurrNet
         {
             comms = GetComponent<DissonanceComms>();
             InstanceHandler.RegisterInstance(this);
+
+            if (startFlags == StartFlags.None)
+            {
+                return;
+            }
+            
 #if UNITY_SERVER
             NetworkManager.main.onServerConnectionState += OnConnectionState;
 #else
@@ -32,6 +38,19 @@ namespace Dissonance.Integrations.PurrNet
             InstanceHandler.UnregisterInstance<PurrNetCommsNetwork>();
             NetworkManager.main.onClientConnectionState -= OnConnectionState;
             NetworkManager.main.onServerConnectionState -= OnConnectionState;
+        }
+
+        /// <summary>
+        /// Try starting PurrNetCommsNetwork manually. Use this if your startFlags is set to None.
+        /// </summary>
+        public void TryRunManually()
+        {
+            if (InstanceHandler.NetworkManager.isHost)
+                RunAsHost(null, null);
+            else if (InstanceHandler.NetworkManager.isServerOnly)
+                RunAsDedicatedServer(null);
+            else if (InstanceHandler.NetworkManager.isClientOnly)
+                RunAsClient(null);
         }
 
         private void OnConnectionState(ConnectionState connectionState)

--- a/Assets/PurrNet-Dissonance/PurrNetServer.cs
+++ b/Assets/PurrNet-Dissonance/PurrNetServer.cs
@@ -20,7 +20,7 @@ namespace Dissonance.Integrations.PurrNet
         protected override void SendReliable(PlayerID connection, ArraySegment<byte> packet)
         {
             if (NetworkManager.main != null && NetworkManager.main.sceneModule != null)
-                if (NetworkManager.main.clientState == ConnectionState.Connected)
+                if (NetworkManager.main.serverState == ConnectionState.Connected)
                     if (NetworkManager.main.sceneModule.TryGetSceneID(_network.gameObject.scene, out var scene))
                     {
                         var bytes = ByteArrayPool.Rent(packet.Count);
@@ -32,7 +32,7 @@ namespace Dissonance.Integrations.PurrNet
         protected override void SendUnreliable(PlayerID connection, ArraySegment<byte> packet)
         {
             if (NetworkManager.main != null && NetworkManager.main.sceneModule != null)
-                if (NetworkManager.main.clientState == ConnectionState.Connected)
+                if (NetworkManager.main.serverState == ConnectionState.Connected)
                     if (NetworkManager.main.sceneModule.TryGetSceneID(_network.gameObject.scene, out var scene))
                     {
                         var bytes = ByteArrayPool.Rent(packet.Count);


### PR DESCRIPTION
1. Fixed the non-functional PurrNetCommsNetwork when building a dedicated server (without a host).
2. Added the ability to start PurrNetCommsNetwork manually (for cases where startFlags is set to None).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now manually trigger network startup and initialization operations with automatic role-based configuration for different deployment scenarios (host, server-only, or client-only modes).

* **Bug Fixes**
  * Fixed server connectivity validation logic to ensure the server connection state is properly verified before transmitting all reliable and unreliable network messages between connected nodes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->